### PR TITLE
Create file .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 djexperience/core/static/* linguist-vendored
 dev/* linguist-vendored
 djexperience/core/templates/* linguist-vendored
+


### PR DESCRIPTION
o linguist do github detecta que o seu projeto tem mais códigos de CSS, Texto plano e HTML do que linhas de código de python(umas das bondades do django de escrever pouco código python ;-)) e automaticamente detecta que a linguagem do projeto é CSS. Crio o arquivo .gitattributes para ignora as rotas do static, templates, MD,  para que o github começa a detectar que é um projeto na linguagem Python, mudando a categoria do seu projeto de CSS a python para que o projeto apareça na busca por linguagem em python.